### PR TITLE
IIntegerParser.`TryParseXYZ` methods now use an `out` instead of taking a `ref`

### DIFF
--- a/Jcd.Formatting.Tests/IntegerEncoderTests.cs
+++ b/Jcd.Formatting.Tests/IntegerEncoderTests.cs
@@ -169,8 +169,8 @@ namespace Jcd.Formatting.Tests
             typeof(NumericMemberDataProvider))]
       public void Format_WhenGivenBigInteger_ReturnsCorrectHexString(BigInteger data)
       {
-         var expected = data.ToString("X").ToLowerInvariant();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = data.ToString("X").ToUpperInvariant();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
 
          // for some odd reason BigInteger zero pads its hex representation. Ensure we've stripped the leading zeros from both. We're looking for hex encoding equivalence, not string equivalence.
          Assert.Equal(expected.TrimLeadingZeros(), actual.TrimLeadingZeros());
@@ -186,8 +186,8 @@ namespace Jcd.Formatting.Tests
             typeof(NumericMemberDataProvider))]
       public void Format_WhenGivenUInt64_ReturnsCorrectHexString(ulong data)
       {
-         var expected = data.ToString("X").ToLowerInvariant();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = data.ToString("X").ToUpperInvariant();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
          Assert.Equal(expected, actual);
          Assert.Equal(data, IntegerEncoders.Hexadecimal.ParseUInt64(actual));
       }
@@ -201,8 +201,8 @@ namespace Jcd.Formatting.Tests
             typeof(NumericMemberDataProvider))]
       public void Format_WhenGivenInt64_ReturnsCorrectHexString(long data)
       {
-         var expected = data.ToString("X").ToLowerInvariant();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = data.ToString("X").ToUpperInvariant();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
          Assert.Equal(expected, actual);
          Assert.Equal(data, IntegerEncoders.Hexadecimal.ParseInt64(actual));
       }
@@ -216,8 +216,8 @@ namespace Jcd.Formatting.Tests
             typeof(NumericMemberDataProvider))]
       public void Format_WhenGivenUInt32_ReturnsCorrectHexString(uint data)
       {
-         var expected = data.ToString("X").ToLowerInvariant();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = data.ToString("X").ToUpperInvariant();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
          Assert.Equal(expected, actual);
          Assert.Equal(data, IntegerEncoders.Hexadecimal.ParseUInt32(actual));
       }
@@ -231,8 +231,8 @@ namespace Jcd.Formatting.Tests
             typeof(NumericMemberDataProvider))]
       public void Format_WhenGivenInt32_ReturnsCorrectHexString(int data)
       {
-         var expected = data.ToString("X").ToLowerInvariant();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = data.ToString("X").ToUpperInvariant();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
          Assert.Equal(expected, actual);
          Assert.Equal(data, IntegerEncoders.Hexadecimal.ParseInt32(actual));
       }
@@ -246,8 +246,8 @@ namespace Jcd.Formatting.Tests
             typeof(NumericMemberDataProvider))]
       public void Format_WhenGivenUInt16_ReturnsCorrectHexString(ushort data)
       {
-         var expected = data.ToString("X").ToLowerInvariant();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = data.ToString("X").ToUpperInvariant();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
          Assert.Equal(expected, actual);
          Assert.Equal(data, IntegerEncoders.Hexadecimal.ParseUInt16(actual));
       }
@@ -261,8 +261,8 @@ namespace Jcd.Formatting.Tests
             typeof(NumericMemberDataProvider))]
       public void Format_WhenGivenInt16_ReturnsCorrectHexString(short data)
       {
-         var expected = data.ToString("X").ToLowerInvariant();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = data.ToString("X").ToUpperInvariant();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
          Assert.Equal(expected, actual);
          Assert.Equal(data, IntegerEncoders.Hexadecimal.ParseInt16(actual));
       }
@@ -276,8 +276,8 @@ namespace Jcd.Formatting.Tests
             typeof(NumericMemberDataProvider))]
       public void Format_WhenGivenByte_ReturnsCorrectHexString(byte data)
       {
-         var expected = data.ToString("X").ToLowerInvariant();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = data.ToString("X").ToUpperInvariant();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
          Assert.Equal(expected, actual);
          Assert.Equal(data, IntegerEncoders.Hexadecimal.ParseByte(actual));
       }
@@ -291,8 +291,8 @@ namespace Jcd.Formatting.Tests
             typeof(NumericMemberDataProvider))]
       public void Format_WhenGivenSByte_ReturnsCorrectHexString(sbyte data)
       {
-         var expected = data.ToString("X").ToLowerInvariant();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = data.ToString("X").ToUpperInvariant();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
          Assert.Equal(expected, actual);
          Assert.Equal(data, IntegerEncoders.Hexadecimal.ParseSByte(actual));
       }
@@ -307,8 +307,8 @@ namespace Jcd.Formatting.Tests
       public void Format_WhenGivenNegativeSByte_ReturnsCorrectHexString(sbyte data)
       {
          var abs = (byte) Math.Abs((short) data);
-         var expected = abs.ToString("X").ToLowerInvariant();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = abs.ToString("X").ToUpperInvariant();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
          Assert.EndsWith(expected, actual);
 
          if (data < 0) Assert.StartsWith("-", actual);
@@ -326,8 +326,8 @@ namespace Jcd.Formatting.Tests
       public void Format_WhenGivenNegativeInt16_ReturnsCorrectHexString(short data)
       {
          var abs = (ushort) Math.Abs((int) data);
-         var expected = abs.ToString("X").ToLowerInvariant();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = abs.ToString("X").ToUpperInvariant();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
          Assert.EndsWith(expected, actual);
 
          if (data < 0) Assert.StartsWith("-", actual);
@@ -345,8 +345,8 @@ namespace Jcd.Formatting.Tests
       public void Format_WhenGivenNegativeInt32_ReturnsCorrectHexString(int data)
       {
          var abs = (uint) Math.Abs((long) data);
-         var expected = abs.ToString("X").ToLowerInvariant();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = abs.ToString("X").ToUpperInvariant();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
          Assert.EndsWith(expected, actual);
 
          if (data < 0) Assert.StartsWith("-", actual);
@@ -364,8 +364,8 @@ namespace Jcd.Formatting.Tests
       public void Format_WhenGivenNegativeInt64_ReturnsCorrectHexString(long data)
       {
          var abs = (ulong) ((BigInteger) data * -1);
-         var expected = abs.ToString("X").ToLowerInvariant();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = abs.ToString("X").ToUpperInvariant();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
          Assert.EndsWith(expected, actual);
 
          if (data < 0) Assert.StartsWith("-", actual);
@@ -383,8 +383,8 @@ namespace Jcd.Formatting.Tests
       public void Format_WhenGivenNegativeBigInteger_ReturnsCorrectHexString(BigInteger data)
       {
          var abs = data * -1;
-         var expected = abs.ToString("X").ToLowerInvariant().TrimLeadingZeros();
-         var actual = IntegerEncoders.Hexadecimal.Format(data).ToLowerInvariant();
+         var expected = abs.ToString("X").ToUpperInvariant().TrimLeadingZeros();
+         var actual = IntegerEncoders.Hexadecimal.Format(data).ToUpperInvariant();
 
          if (data < 0) Assert.StartsWith("-", actual);
 
@@ -400,9 +400,8 @@ namespace Jcd.Formatting.Tests
       [InlineData(NonBinaryNegativeTestData, false)]
       public void TryParseBigInteger_WhenGivenText_ReturnsTrueWhenDecodedFalseWhenNot(string text, bool parsed)
       {
-         BigInteger result = 0;
-         BigInteger expectedParsedResult = 11; // BigInteger can't be const. Have to use this hack.
-         Assert.Equal(parsed, IntegerEncoders.Binary.TryParseBigInteger(text, ref result));
+          BigInteger expectedParsedResult = 11; // BigInteger can't be const. Have to use this hack.
+         Assert.Equal(parsed, IntegerEncoders.Binary.TryParseBigInteger(text, out var result));
 
          if (parsed) Assert.Equal(expectedParsedResult, result);
       }
@@ -417,8 +416,7 @@ namespace Jcd.Formatting.Tests
                                                                                   bool parsed,
                                                                                   ulong decoded)
       {
-         ulong result = 0;
-         Assert.Equal(parsed, IntegerEncoders.Binary.TryParseUInt64(text, ref result));
+          Assert.Equal(parsed, IntegerEncoders.Binary.TryParseUInt64(text, out var result));
 
          if (parsed) Assert.Equal(decoded, result);
       }
@@ -433,8 +431,7 @@ namespace Jcd.Formatting.Tests
                                                                                  bool parsed,
                                                                                  long decoded)
       {
-         long result = 0;
-         Assert.Equal(parsed, IntegerEncoders.Binary.TryParseInt64(text, ref result));
+          Assert.Equal(parsed, IntegerEncoders.Binary.TryParseInt64(text, out var result));
 
          if (parsed) Assert.Equal(decoded, result);
       }
@@ -449,8 +446,7 @@ namespace Jcd.Formatting.Tests
                                                                                   bool parsed,
                                                                                   uint decoded)
       {
-         uint result = 0;
-         Assert.Equal(parsed, IntegerEncoders.Binary.TryParseUInt32(text, ref result));
+          Assert.Equal(parsed, IntegerEncoders.Binary.TryParseUInt32(text, out var result));
 
          if (parsed) Assert.Equal(decoded, result);
       }
@@ -465,8 +461,7 @@ namespace Jcd.Formatting.Tests
                                                                                  bool parsed,
                                                                                  int decoded)
       {
-         var result = 0;
-         Assert.Equal(parsed, IntegerEncoders.Binary.TryParseInt32(text, ref result));
+          Assert.Equal(parsed, IntegerEncoders.Binary.TryParseInt32(text, out var result));
 
          if (parsed) Assert.Equal(decoded, result);
       }
@@ -481,8 +476,7 @@ namespace Jcd.Formatting.Tests
                                                                                   bool parsed,
                                                                                   ushort decoded)
       {
-         ushort result = 0;
-         Assert.Equal(parsed, IntegerEncoders.Binary.TryParseUInt16(text, ref result));
+          Assert.Equal(parsed, IntegerEncoders.Binary.TryParseUInt16(text, out var result));
 
          if (parsed) Assert.Equal(decoded, result);
       }
@@ -497,8 +491,7 @@ namespace Jcd.Formatting.Tests
                                                                                  bool parsed,
                                                                                  short decoded)
       {
-         short result = 0;
-         Assert.Equal(parsed, IntegerEncoders.Binary.TryParseInt16(text, ref result));
+          Assert.Equal(parsed, IntegerEncoders.Binary.TryParseInt16(text, out var result));
 
          if (parsed) Assert.Equal(decoded, result);
       }
@@ -513,8 +506,7 @@ namespace Jcd.Formatting.Tests
                                                                                 bool parsed,
                                                                                 byte decoded)
       {
-         byte result = 0;
-         Assert.Equal(parsed, IntegerEncoders.Binary.TryParseByte(text, ref result));
+          Assert.Equal(parsed, IntegerEncoders.Binary.TryParseByte(text, out var result));
 
          if (parsed) Assert.Equal(decoded, result);
       }
@@ -529,8 +521,7 @@ namespace Jcd.Formatting.Tests
                                                                                  bool parsed,
                                                                                  sbyte decoded)
       {
-         sbyte result = 0;
-         Assert.Equal(parsed, IntegerEncoders.Binary.TryParseSByte(text, ref result));
+          Assert.Equal(parsed, IntegerEncoders.Binary.TryParseSByte(text, out var result));
 
          if (parsed) Assert.Equal(decoded, result);
       }

--- a/Jcd.Formatting/IIntegerParser.cs
+++ b/Jcd.Formatting/IIntegerParser.cs
@@ -172,7 +172,7 @@ namespace Jcd.Formatting
       /// <param name="value">the text to parse</param>
       /// <param name="result">the resultant value</param>
       /// <returns>true if successfully parsed, false otherwise</returns>
-      bool TryParseBigInteger(string value, ref BigInteger result);
+      bool TryParseBigInteger(string value, out BigInteger result);
 
       /// <summary>
       ///    Tries to parse a Byte from the provided text.
@@ -180,7 +180,7 @@ namespace Jcd.Formatting
       /// <param name="value">the text to parse</param>
       /// <param name="result">the resultant value</param>
       /// <returns>true if successfully parsed, false otherwise</returns>
-      bool TryParseByte(string value, ref byte result);
+      bool TryParseByte(string value, out byte result);
 
       /// <summary>
       ///    Tries to parse a Int16 from the provided text.
@@ -188,7 +188,7 @@ namespace Jcd.Formatting
       /// <param name="value">the text to parse</param>
       /// <param name="result">the resultant value</param>
       /// <returns>true if successfully parsed, false otherwise</returns>
-      bool TryParseInt16(string value, ref short result);
+      bool TryParseInt16(string value, out short result);
 
       /// <summary>
       ///    Tries to parse a Int32 from the provided text.
@@ -196,7 +196,7 @@ namespace Jcd.Formatting
       /// <param name="value">the text to parse</param>
       /// <param name="result">the resultant value</param>
       /// <returns>true if successfully parsed, false otherwise</returns>
-      bool TryParseInt32(string value, ref int result);
+      bool TryParseInt32(string value, out int result);
 
       /// <summary>
       ///    Tries to parse a Int64 from the provided text.
@@ -204,7 +204,7 @@ namespace Jcd.Formatting
       /// <param name="value">the text to parse</param>
       /// <param name="result">the resultant value</param>
       /// <returns>true if successfully parsed, false otherwise</returns>
-      bool TryParseInt64(string value, ref long result);
+      bool TryParseInt64(string value, out long result);
 
       /// <summary>
       ///    Tries to parse a SByte from the provided text.
@@ -212,7 +212,7 @@ namespace Jcd.Formatting
       /// <param name="value">the text to parse</param>
       /// <param name="result">the resultant value</param>
       /// <returns>true if successfully parsed, false otherwise</returns>
-      bool TryParseSByte(string value, ref sbyte result);
+      bool TryParseSByte(string value, out sbyte result);
 
       /// <summary>
       ///    Tries to parse a UInt16 from the provided text.
@@ -220,7 +220,7 @@ namespace Jcd.Formatting
       /// <param name="value">the text to parse</param>
       /// <param name="result">the resultant value</param>
       /// <returns>true if successfully parsed, false otherwise</returns>
-      bool TryParseUInt16(string value, ref ushort result);
+      bool TryParseUInt16(string value, out ushort result);
 
       /// <summary>
       ///    Tries to parse a UInt32 from the provided text.
@@ -228,7 +228,7 @@ namespace Jcd.Formatting
       /// <param name="value">the text to parse</param>
       /// <param name="result">the resultant value</param>
       /// <returns>true if successfully parsed, false otherwise</returns>
-      bool TryParseUInt32(string value, ref uint result);
+      bool TryParseUInt32(string value, out uint result);
 
       /// <summary>
       ///    Tries to parse a UInt64 from the provided text.
@@ -236,7 +236,7 @@ namespace Jcd.Formatting
       /// <param name="value">the text to parse</param>
       /// <param name="result">the resultant value</param>
       /// <returns>true if successfully parsed, false otherwise</returns>
-      bool TryParseUInt64(string value, ref ulong result);
+      bool TryParseUInt64(string value, out ulong result);
 
       #endregion Public Methods
    }

--- a/Jcd.Formatting/IntegerEncoder.cs
+++ b/Jcd.Formatting/IntegerEncoder.cs
@@ -3,868 +3,880 @@ using System.Collections.Generic;
 using System.Numerics;
 using Jcd.Reflection;
 using Jcd.Validations;
+
 // ReSharper disable MemberCanBePrivate.Global
 // ReSharper disable UnusedMember.Global
 
 namespace Jcd.Formatting
 {
-   /// <summary>
-   ///    A class that performs integer encoding to text in an arbitrary base, as well as parsing
-   ///    text encoded in the same manner.
-   /// </summary>
-   public class IntegerEncoder : CustomFormatterBase, IIntegerFormatter, IIntegerParser
-   {
-      #region Public Fields
+    /// <summary>
+    ///    A class that performs integer encoding to text in an arbitrary base, as well as parsing
+    ///    text encoded in the same manner.
+    /// </summary>
+    public class IntegerEncoder : CustomFormatterBase, IIntegerFormatter, IIntegerParser
+    {
+        #region Public Fields
 
-      /// <summary>
-      ///    The numeric base of the encoder
-      /// </summary>
-      public readonly ushort Base;
+        /// <summary>
+        ///    The numeric base of the encoder
+        /// </summary>
+        public readonly ushort Base;
 
-      /// <summary>
-      ///    Indicates if the characters that are decoded/encoded are case sensitive.
-      /// </summary>
-      public readonly bool CaseSensitive;
+        /// <summary>
+        ///    Indicates if the characters that are decoded/encoded are case sensitive.
+        /// </summary>
+        public readonly bool CaseSensitive;
 
-      /// <summary>
-      ///    The character set used for encoding and decoding (for simple decoders)
-      /// </summary>
-      public readonly string CharacterSet;
+        /// <summary>
+        ///    The character set used for encoding and decoding (for simple decoders)
+        /// </summary>
+        public readonly string CharacterSet;
 
-      /// <summary>
-      ///    A flag that indicates if the values of the character set are numerically increasing. Using this can allow for faster
-      ///    sorts of short numbers by NOT decoding first. (i.e. For positive numbers the text will sort the same as the number)
-      /// </summary>
-      public readonly bool CharacterSetValuesAlwaysIncrease;
+        /// <summary>
+        ///    A flag that indicates if the values of the character set are numerically increasing. Using this can allow for faster
+        ///    sorts of short numbers by NOT decoding first. (i.e. For positive numbers the text will sort the same as the number)
+        /// </summary>
+        public readonly bool CharacterSetValuesAlwaysIncrease;
 
-      #endregion Public Fields
+        #endregion Public Fields
 
-      #region Private Fields
+        #region Private Fields
 
-      private static readonly Type[] FormattableTypes =
-      {
-         typeof(byte),
-         typeof(sbyte),
-         typeof(ushort),
-         typeof(short),
-         typeof(int),
-         typeof(uint),
-         typeof(long),
-         typeof(ulong)
-      };
+        private static readonly Type[] FormattableTypes =
+        {
+            typeof(byte),
+            typeof(sbyte),
+            typeof(ushort),
+            typeof(short),
+            typeof(int),
+            typeof(uint),
+            typeof(long),
+            typeof(ulong)
+        };
 
-      private readonly Dictionary<char, int> _charToValue = new Dictionary<char, int>();
+        private readonly Dictionary<char, int> _charToValue = new Dictionary<char, int>();
 
-      #endregion Private Fields
+        #endregion Private Fields
 
-      #region Public Constructors
+        #region Public Constructors
 
-      /// <summary>
-      ///    Constructs an encoder when given a character set to encode to, and an array of decode
-      ///    mappings. (This is to support Crockford encoding/decoding)
-      /// </summary>
-      /// <param name="encodeCharacterSet">
-      ///    The set of characters to use when encoding a number to text.
-      /// </param>
-      /// <param name="decodeCharacterSet">
-      ///    The set of decode character mappings (i.e. which sets of characters map to which numeric
-      ///    base value.)
-      /// </param>
-      public IntegerEncoder(string encodeCharacterSet, string[] decodeCharacterSet)
-         : base(FormattableTypes, Format)
-      {
-         Argument.IsNotNullWhitespaceOrEmpty(encodeCharacterSet, nameof(encodeCharacterSet));
-         Argument.HasItems(Argument.IsNotNull(decodeCharacterSet, nameof(decodeCharacterSet)), nameof(decodeCharacterSet));
+        /// <summary>
+        ///    Constructs an encoder when given a character set to encode to, and an array of decode
+        ///    mappings. (This is to support Crockford encoding/decoding)
+        /// </summary>
+        /// <param name="encodeCharacterSet">
+        ///    The set of characters to use when encoding a number to text.
+        /// </param>
+        /// <param name="decodeCharacterSet">
+        ///    The set of decode character mappings (i.e. which sets of characters map to which numeric
+        ///    base value.)
+        /// </param>
+        public IntegerEncoder(string encodeCharacterSet, string[] decodeCharacterSet)
+            : base(FormattableTypes, Format)
+        {
+            Argument.IsNotNullWhitespaceOrEmpty(encodeCharacterSet, nameof(encodeCharacterSet));
+            Argument.HasItems(Argument.IsNotNull(decodeCharacterSet, nameof(decodeCharacterSet)),
+                nameof(decodeCharacterSet));
 
-         Argument.AreEqual(decodeCharacterSet.Length,
-                           encodeCharacterSet.Length,
-                           message: "decodeCharacterSet and encodeCharacterSet must be the same length.");
+            Argument.AreEqual(decodeCharacterSet.Length,
+                encodeCharacterSet.Length,
+                message: "decodeCharacterSet and encodeCharacterSet must be the same length.");
 
-         CaseSensitive = true;
-         CharacterSet = encodeCharacterSet;
-         Base = (ushort) CharacterSet.Length;
+            CaseSensitive = true;
+            CharacterSet = encodeCharacterSet;
+            Base = (ushort)CharacterSet.Length;
 
-         for (var i = 0; i < decodeCharacterSet.Length; i++)
-         {
-            foreach (var c in decodeCharacterSet[i])
+            for (var i = 0; i < decodeCharacterSet.Length; i++)
             {
-               _charToValue.Add(c, i);
-            }
-         }
-
-         // now validate that there is the ability to decode that which we encode.
-         for (var i = 0; i < encodeCharacterSet.Length; i++)
-         {
-            var ec = encodeCharacterSet[i];
-
-            if (!_charToValue.ContainsKey(ec))
-            {
-               throw new ArgumentException($"Encoding char: {ec} was not found in the decode set.",
-                                           nameof(encodeCharacterSet));
+                foreach (var c in decodeCharacterSet[i])
+                {
+                    _charToValue.Add(c, i);
+                }
             }
 
-            var dv = _charToValue[ec];
-
-            if (dv != i)
+            // now validate that there is the ability to decode that which we encode.
+            for (var i = 0; i < encodeCharacterSet.Length; i++)
             {
-               throw new ArgumentException(
-                                           $"Encoding char: {ec} was expected to decode to {i} but decoded to {dv}.",
-                                           nameof(decodeCharacterSet));
+                var ec = encodeCharacterSet[i];
+
+                if (!_charToValue.ContainsKey(ec))
+                {
+                    throw new ArgumentException($"Encoding char: {ec} was not found in the decode set.",
+                        nameof(encodeCharacterSet));
+                }
+
+                var dv = _charToValue[ec];
+
+                if (dv != i)
+                {
+                    throw new ArgumentException(
+                        $"Encoding char: {ec} was expected to decode to {i} but decoded to {dv}.",
+                        nameof(decodeCharacterSet));
+                }
             }
-         }
-      }
+        }
 
-      /// <summary>
-      ///    Constructs an encoder when given an alphabet with exact encoding to decoding matching.
-      /// </summary>
-      /// <param name="characterSet">
-      ///    The character set to use for encoding and decoding. (where length = n, char at index 0=0,
-      ///    char at n-1=n-1)
-      /// </param>
-      /// <param name="caseSensitive">indicates if the characters are case sensitive for encoding/decoding.</param>
-      public IntegerEncoder(string characterSet, bool caseSensitive = false)
-         : base(FormattableTypes, Format)
-      {
-         Argument.IsNotNullWhitespaceOrEmpty(characterSet, nameof(characterSet));
-         Argument.IsGreaterThan(characterSet.Length, 0, "characterSet.Length");
-         CaseSensitive = caseSensitive;
-         CharacterSet = caseSensitive ? characterSet : characterSet.ToLowerInvariant();
-         Base = (ushort) CharacterSet.Length;
-         var i = 0;
-         var pc = '\0';
-         CharacterSetValuesAlwaysIncrease = true;
+        /// <summary>
+        ///    Constructs an encoder when given an alphabet with exact encoding to decoding matching.
+        /// </summary>
+        /// <param name="characterSet">
+        ///    The character set to use for encoding and decoding. (where length = n, char at index 0=0,
+        ///    char at n-1=n-1)
+        /// </param>
+        /// <param name="caseSensitive">indicates if the characters are case sensitive for encoding/decoding.</param>
+        public IntegerEncoder(string characterSet, bool caseSensitive = false)
+            : base(FormattableTypes, Format)
+        {
+            Argument.IsNotNullWhitespaceOrEmpty(characterSet, nameof(characterSet));
+            Argument.IsGreaterThan(characterSet.Length, 0, "characterSet.Length");
+            CaseSensitive = caseSensitive;
+            CharacterSet = caseSensitive ? characterSet : characterSet.ToUpperInvariant();
+            Base = (ushort)CharacterSet.Length;
+            var i = 0;
+            var pc = '\0';
+            CharacterSetValuesAlwaysIncrease = true;
 
-         foreach (var c in CharacterSet)
-         {
-            _charToValue.Add(c, i);
-
-            if (CharacterSetValuesAlwaysIncrease && pc > c) 
-               CharacterSetValuesAlwaysIncrease = false;
-
-            pc = c;
-            i++;
-         }
-      }
-
-      /// <summary>
-      /// Constructs an IntegerEncoder
-      /// </summary>
-      /// <param name="base"></param>
-      /// <param name="caseSensitive"></param>
-      /// <param name="characterSet"></param>
-      /// <param name="characterSetValuesAlwaysIncrease"></param>
-      /// <param name="charToValue"></param>
-      /// <exception cref="ArgumentNullException"></exception>
-      public IntegerEncoder(ushort @base, bool caseSensitive, string characterSet, bool characterSetValuesAlwaysIncrease, Dictionary<char, int> charToValue)
-         : base(FormattableTypes, Format)
-      {
-         Argument.IsNotNull(characterSet,nameof(characterSet));
-         Argument.IsNotNull(charToValue,nameof(charToValue));
-         
-         Base = @base;
-         CaseSensitive = caseSensitive;
-         CharacterSet = characterSet;
-         CharacterSetValuesAlwaysIncrease = characterSetValuesAlwaysIncrease;
-         _charToValue = charToValue;
-      }
-
-      #endregion Public Constructors
-
-      #region Public Methods
-
-      /// <inheritdoc />
-      public string Format(uint value)
-      {
-         var sb = new List<char>();
-         var cv = value;
-
-         while (cv > 0)
-         {
-            var r = (int) (cv % Base);
-            sb.Add(CharacterSet[r]);
-            cv /= Base;
-         }
-
-         return FormatResult(sb);
-      }
-
-      /// <inheritdoc />
-      public string Format(ulong value)
-      {
-         var sb = new List<char>();
-         var cv = value;
-
-         while (cv > 0)
-         {
-            var r = (int) (cv % Base);
-            sb.Add(CharacterSet[r]);
-            cv /= Base;
-         }
-
-         return FormatResult(sb);
-      }
-
-      /// <inheritdoc />
-      public string Format(ushort value)
-      {
-         var sb = new List<char>();
-         var cv = value;
-
-         while (cv > 0)
-         {
-            var r = cv % Base;
-            sb.Add(CharacterSet[r]);
-            cv = (ushort) (cv / Base);
-         }
-
-         return FormatResult(sb);
-      }
-
-      /// <inheritdoc />
-      public string Format(byte value)
-      {
-         var sb = new List<char>();
-         var cv = value;
-
-         while (cv > 0)
-         {
-            var r = cv % Base;
-            sb.Add(CharacterSet[r]);
-            cv = (byte) (cv / Base);
-         }
-
-         return FormatResult(sb);
-      }
-
-      /// <inheritdoc />
-      public string Format(int value)
-      {
-         var sb = new List<char>();
-         var cv = value;
-
-         if (cv < 1)
-         {
-            while (cv < 0)
+            foreach (var c in CharacterSet)
             {
-               var r = cv % Base;
-               sb.Add(CharacterSet[Math.Abs(r)]);
-               cv /= Base;
+                _charToValue.Add(c, i);
+
+                if (CharacterSetValuesAlwaysIncrease && pc > c)
+                    CharacterSetValuesAlwaysIncrease = false;
+
+                pc = c;
+                i++;
             }
-         }
-         else
-         {
+        }
+
+        /// <summary>
+        /// Constructs an IntegerEncoder
+        /// </summary>
+        /// <param name="base"></param>
+        /// <param name="caseSensitive"></param>
+        /// <param name="characterSet"></param>
+        /// <param name="characterSetValuesAlwaysIncrease"></param>
+        /// <param name="charToValue"></param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public IntegerEncoder(ushort @base, bool caseSensitive, string characterSet,
+                              bool characterSetValuesAlwaysIncrease, Dictionary<char, int> charToValue)
+            : base(FormattableTypes, Format)
+        {
+            Argument.IsNotNull(characterSet, nameof(characterSet));
+            Argument.IsNotNull(charToValue, nameof(charToValue));
+
+            Base = @base;
+            CaseSensitive = caseSensitive;
+            CharacterSet = characterSet;
+            CharacterSetValuesAlwaysIncrease = characterSetValuesAlwaysIncrease;
+            _charToValue = charToValue;
+        }
+
+        #endregion Public Constructors
+
+        #region Public Methods
+
+        /// <inheritdoc />
+        public string Format(uint value)
+        {
+            var sb = new List<char>();
+            var cv = value;
+
             while (cv > 0)
             {
-               var r = cv % Base;
-               sb.Add(CharacterSet[r]);
-               cv /= Base;
+                var r = (int)(cv % Base);
+                sb.Add(CharacterSet[r]);
+                cv /= Base;
             }
-         }
 
-         if (value < 0) sb.Add('-');
+            return FormatResult(sb);
+        }
 
-         return FormatResult(sb);
-      }
+        /// <inheritdoc />
+        public string Format(ulong value)
+        {
+            var sb = new List<char>();
+            var cv = value;
 
-      /// <inheritdoc />
-      public string Format(long value)
-      {
-         var sb = new List<char>();
-         var cv = value;
-
-         if (cv < 1)
-         {
-            while (cv < 0)
-            {
-               var r = (int) (cv % Base);
-               sb.Add(CharacterSet[Math.Abs(r)]);
-               cv /= Base;
-            }
-         }
-         else
-         {
             while (cv > 0)
             {
-               var r = (int) (cv % Base);
-               sb.Add(CharacterSet[r]);
-               cv /= Base;
+                var r = (int)(cv % Base);
+                sb.Add(CharacterSet[r]);
+                cv /= Base;
             }
-         }
 
-         if (value < 0) sb.Add('-');
+            return FormatResult(sb);
+        }
 
-         return FormatResult(sb);
-      }
+        /// <inheritdoc />
+        public string Format(ushort value)
+        {
+            var sb = new List<char>();
+            var cv = value;
 
-      /// <inheritdoc />
-      public string Format(short value)
-      {
-         var sb = new List<char>();
-         var cv = value;
-
-         if (cv < 1)
-         {
-            while (cv < 0)
-            {
-               var r = cv % Base;
-               sb.Add(CharacterSet[Math.Abs(r)]);
-               cv = (short) (cv / Base);
-            }
-         }
-         else
-         {
             while (cv > 0)
             {
-               var r = cv % Base;
-               sb.Add(CharacterSet[r]);
-               cv = (short) (cv / Base);
+                var r = cv % Base;
+                sb.Add(CharacterSet[r]);
+                cv = (ushort)(cv / Base);
             }
-         }
 
-         if (value < 0) sb.Add('-');
+            return FormatResult(sb);
+        }
 
-         return FormatResult(sb);
-      }
+        /// <inheritdoc />
+        public string Format(byte value)
+        {
+            var sb = new List<char>();
+            var cv = value;
 
-      /// <inheritdoc />
-      public string Format(sbyte value)
-      {
-         var sb = new List<char>();
-         var cv = value;
-
-         if (cv < 1)
-         {
-            while (cv < 0)
-            {
-               var r = cv % Base;
-               sb.Add(CharacterSet[Math.Abs(r)]);
-               cv = (sbyte) (cv / Base);
-            }
-         }
-         else
-         {
             while (cv > 0)
             {
-               var r = cv % Base;
-               sb.Add(CharacterSet[r]);
-               cv = (sbyte) (cv / Base);
+                var r = cv % Base;
+                sb.Add(CharacterSet[r]);
+                cv = (byte)(cv / Base);
             }
-         }
 
-         if (value < 0) sb.Add('-');
+            return FormatResult(sb);
+        }
 
-         return FormatResult(sb);
-      }
+        /// <inheritdoc />
+        public string Format(int value)
+        {
+            var sb = new List<char>();
+            var cv = value;
 
-      /// <inheritdoc />
-      public string Format(BigInteger value)
-      {
-         var sb = new List<char>();
-         var cv = value;
-
-         if (cv < 1) cv *= -1;
-
-         while (cv > 0)
-         {
-            var br = cv % (int) Base;
-            var r = (int) br;
-            sb.Add(CharacterSet[r]);
-            cv /= Base;
-         }
-
-         if (value < 0) sb.Add('-');
-
-         return FormatResult(sb);
-      }
-
-      /// <inheritdoc />
-      public BigInteger ParseBigInteger(string value)
-      {
-         Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
-
-         if (!CaseSensitive) value = value.ToLowerInvariant();
-
-         var result = (BigInteger) 0;
-         var isNeg = value[0] == '-';
-         var digits = ExtractCoreDigits(value);
-
-         foreach (var digit in digits)
-         {
-            result *= Base;
-
-            if (!_charToValue.ContainsKey(digit))
+            if (cv < 1)
             {
-               throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
+                while (cv < 0)
+                {
+                    var r = cv % Base;
+                    sb.Add(CharacterSet[Math.Abs(r)]);
+                    cv /= Base;
+                }
             }
-
-            result += _charToValue[digit];
-         }
-
-         return isNeg ? -1 * result : result;
-      }
-
-      /// <inheritdoc />
-      public byte ParseByte(string value)
-      {
-         Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
-
-         if (!CaseSensitive) value = value.ToLowerInvariant();
-
-         var result = (byte) 0;
-
-         if (value[0] == '-')
-         {
-            throw new ArgumentException("A negative number cannot be converted into unsigned.", nameof(value));
-         }
-
-         var digits = ExtractCoreDigits(value);
-
-         foreach (var digit in digits)
-         {
-            checked
+            else
             {
-               result *= (byte) Base;
-
-               if (!_charToValue.ContainsKey(digit))
-               {
-                  throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
-               }
-
-               result += (byte) _charToValue[digit];
+                while (cv > 0)
+                {
+                    var r = cv % Base;
+                    sb.Add(CharacterSet[r]);
+                    cv /= Base;
+                }
             }
-         }
 
-         return result;
-      }
+            if (value < 0) sb.Add('-');
 
-      /// <inheritdoc />
-      public short ParseInt16(string value)
-      {
-         Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
+            return FormatResult(sb);
+        }
 
-         if (!CaseSensitive) value = value.ToLowerInvariant();
+        /// <inheritdoc />
+        public string Format(long value)
+        {
+            var sb = new List<char>();
+            var cv = value;
 
-         var result = (short) 0;
-         var isNeg = value[0] == '-' ? (short) -1 : (short) 1;
-         var digits = ExtractCoreDigits(value);
-
-         foreach (var digit in digits)
-         {
-            checked
+            if (cv < 1)
             {
-               result *= (short) Base;
-
-               if (!_charToValue.ContainsKey(digit))
-               {
-                  throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
-               }
-
-               result += (short) (_charToValue[digit] * isNeg);
+                while (cv < 0)
+                {
+                    var r = (int)(cv % Base);
+                    sb.Add(CharacterSet[Math.Abs(r)]);
+                    cv /= Base;
+                }
             }
-         }
-
-         return result;
-      }
-
-      /// <inheritdoc />
-      public int ParseInt32(string value)
-      {
-         Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
-
-         if (!CaseSensitive) value = value.ToLowerInvariant();
-
-         var result = 0;
-         var isNeg = value[0] == '-' ? -1 : 1;
-         var digits = ExtractCoreDigits(value);
-
-         foreach (var digit in digits)
-         {
-            checked
+            else
             {
-               result *= Base;
-
-               if (!_charToValue.ContainsKey(digit))
-               {
-                  throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
-               }
-
-               result += _charToValue[digit] * isNeg;
+                while (cv > 0)
+                {
+                    var r = (int)(cv % Base);
+                    sb.Add(CharacterSet[r]);
+                    cv /= Base;
+                }
             }
-         }
 
-         return result;
-      }
+            if (value < 0) sb.Add('-');
 
-      /// <inheritdoc />
-      public long ParseInt64(string value)
-      {
-         Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
+            return FormatResult(sb);
+        }
 
-         if (!CaseSensitive) value = value.ToLowerInvariant();
+        /// <inheritdoc />
+        public string Format(short value)
+        {
+            var sb = new List<char>();
+            var cv = value;
 
-         var result = (long) 0;
-         var isNeg = value[0] == '-'; // ? -1 : 1;
-         var digits = ExtractCoreDigits(value);
-
-         foreach (var digit in digits)
-         {
-            checked
+            if (cv < 1)
             {
-               result *= Base;
-
-               if (!_charToValue.ContainsKey(digit))
-               {
-                  throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
-               }
-
-               result += _charToValue[digit] * (isNeg ? -1 : 1);
+                while (cv < 0)
+                {
+                    var r = cv % Base;
+                    sb.Add(CharacterSet[Math.Abs(r)]);
+                    cv = (short)(cv / Base);
+                }
             }
-         }
-
-         return result;
-      }
-
-      /// <inheritdoc />
-      public sbyte ParseSByte(string value)
-      {
-         Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
-
-         if (!CaseSensitive) value = value.ToLowerInvariant();
-
-         var result = (sbyte) 0;
-         var isNeg = (sbyte) (value[0] == '-' ? -1 : 1);
-         var digits = ExtractCoreDigits(value);
-
-         foreach (var digit in digits)
-         {
-            checked
+            else
             {
-               result *= (sbyte) Base;
-
-               if (!_charToValue.ContainsKey(digit))
-               {
-                  throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
-               }
-
-               result += (sbyte) (_charToValue[digit] * isNeg);
+                while (cv > 0)
+                {
+                    var r = cv % Base;
+                    sb.Add(CharacterSet[r]);
+                    cv = (short)(cv / Base);
+                }
             }
-         }
 
-         return result;
-      }
+            if (value < 0) sb.Add('-');
 
-      /// <inheritdoc />
-      public ushort ParseUInt16(string value)
-      {
-         Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
+            return FormatResult(sb);
+        }
 
-         if (!CaseSensitive) value = value.ToLowerInvariant();
+        /// <inheritdoc />
+        public string Format(sbyte value)
+        {
+            var sb = new List<char>();
+            var cv = value;
 
-         var result = (ushort) 0;
-
-         if (value[0] == '-')
-         {
-            throw new ArgumentException("A negative number cannot be converted into unsigned.", nameof(value));
-         }
-
-         var digits = ExtractCoreDigits(value);
-
-         foreach (var digit in digits)
-         {
-            checked
+            if (cv < 1)
             {
-               result *= Base;
-
-               if (!_charToValue.ContainsKey(digit))
-               {
-                  throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
-               }
-
-               result += (ushort) _charToValue[digit];
+                while (cv < 0)
+                {
+                    var r = cv % Base;
+                    sb.Add(CharacterSet[Math.Abs(r)]);
+                    cv = (sbyte)(cv / Base);
+                }
             }
-         }
-
-         return result;
-      }
-
-      /// <inheritdoc />
-      public uint ParseUInt32(string value)
-      {
-         Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
-
-         if (!CaseSensitive) value = value.ToLowerInvariant();
-
-         var result = (uint) 0;
-
-         if (value[0] == '-')
-         {
-            throw new ArgumentException("A negative number cannot be converted into unsigned.", nameof(value));
-         }
-
-         var digits = ExtractCoreDigits(value);
-
-         foreach (var digit in digits)
-         {
-            checked
+            else
             {
-               result *= Base;
-
-               if (!_charToValue.ContainsKey(digit))
-               {
-                  throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
-               }
-
-               result += (uint) _charToValue[digit];
+                while (cv > 0)
+                {
+                    var r = cv % Base;
+                    sb.Add(CharacterSet[r]);
+                    cv = (sbyte)(cv / Base);
+                }
             }
-         }
 
-         return result;
-      }
+            if (value < 0) sb.Add('-');
 
-      /// <inheritdoc />
-      public ulong ParseUInt64(string value)
-      {
-         Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
+            return FormatResult(sb);
+        }
 
-         if (!CaseSensitive) value = value.ToLowerInvariant();
+        /// <inheritdoc />
+        public string Format(BigInteger value)
+        {
+            var sb = new List<char>();
+            var cv = value;
 
-         var result = (ulong) 0;
+            if (cv < 1) cv *= -1;
 
-         if (value[0] == '-')
-         {
-            throw new ArgumentException("A negative number cannot be converted into unsigned.", nameof(value));
-         }
-
-         var digits = ExtractCoreDigits(value);
-
-         foreach (var digit in digits)
-         {
-            checked
+            while (cv > 0)
             {
-               result *= Base;
-
-               if (!_charToValue.ContainsKey(digit))
-               {
-                  throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
-               }
-
-               result += (ulong) _charToValue[digit];
+                var br = cv % (int)Base;
+                var r = (int)br;
+                sb.Add(CharacterSet[r]);
+                cv /= Base;
             }
-         }
 
-         return result;
-      }
+            if (value < 0) sb.Add('-');
 
-      /// <inheritdoc />
-      public bool TryParseBigInteger(string value, ref BigInteger result)
-      {
-         try
-         {
-            result = ParseBigInteger(value);
+            return FormatResult(sb);
+        }
 
-            return true;
-         }
-         catch
-         {
-            return false;
-         }
-      }
+        /// <inheritdoc />
+        public BigInteger ParseBigInteger(string value)
+        {
+            Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
 
-      /// <inheritdoc />
-      public bool TryParseByte(string value, ref byte result)
-      {
-         try
-         {
-            result = ParseByte(value);
+            if (!CaseSensitive) value = value.ToUpperInvariant();
 
-            return true;
-         }
-         catch
-         {
-            return false;
-         }
-      }
+            var result = (BigInteger)0;
+            var isNeg = value[0] == '-';
+            var digits = ExtractCoreDigits(value);
 
-      /// <inheritdoc />
-      public bool TryParseInt16(string value, ref short result)
-      {
-         try
-         {
-            result = ParseInt16(value);
+            foreach (var digit in digits)
+            {
+                result *= Base;
 
-            return true;
-         }
-         catch
-         {
-            return false;
-         }
-      }
+                if (!_charToValue.ContainsKey(digit))
+                {
+                    throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
+                }
 
-      /// <inheritdoc />
-      public bool TryParseInt32(string value, ref int result)
-      {
-         try
-         {
-            result = ParseInt32(value);
+                result += _charToValue[digit];
+            }
 
-            return true;
-         }
-         catch
-         {
-            return false;
-         }
-      }
+            return isNeg ? -1 * result : result;
+        }
 
-      /// <inheritdoc />
-      public bool TryParseInt64(string value, ref long result)
-      {
-         try
-         {
-            result = ParseInt64(value);
+        /// <inheritdoc />
+        public byte ParseByte(string value)
+        {
+            Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
 
-            return true;
-         }
-         catch
-         {
-            return false;
-         }
-      }
+            if (!CaseSensitive) value = value.ToUpperInvariant();
 
-      /// <inheritdoc />
-      public bool TryParseSByte(string value, ref sbyte result)
-      {
-         try
-         {
-            result = ParseSByte(value);
+            var result = (byte)0;
 
-            return true;
-         }
-         catch
-         {
-            return false;
-         }
-      }
+            if (value[0] == '-')
+            {
+                throw new ArgumentException("A negative number cannot be converted into unsigned.", nameof(value));
+            }
 
-      /// <inheritdoc />
-      public bool TryParseUInt16(string value, ref ushort result)
-      {
-         try
-         {
-            result = ParseUInt16(value);
+            var digits = ExtractCoreDigits(value);
 
-            return true;
-         }
-         catch
-         {
-            return false;
-         }
-      }
+            foreach (var digit in digits)
+            {
+                checked
+                {
+                    result *= (byte)Base;
 
-      /// <inheritdoc />
-      public bool TryParseUInt32(string value, ref uint result)
-      {
-         try
-         {
-            result = ParseUInt32(value);
+                    if (!_charToValue.ContainsKey(digit))
+                    {
+                        throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
+                    }
 
-            return true;
-         }
-         catch
-         {
-            return false;
-         }
-      }
+                    result += (byte)_charToValue[digit];
+                }
+            }
 
-      /// <inheritdoc />
-      public bool TryParseUInt64(string value, ref ulong result)
-      {
-         try
-         {
-            result = ParseUInt64(value);
+            return result;
+        }
 
-            return true;
-         }
-         catch
-         {
-            return false;
-         }
-      }
+        /// <inheritdoc />
+        public short ParseInt16(string value)
+        {
+            Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
 
-      #endregion Public Methods
+            if (!CaseSensitive) value = value.ToUpperInvariant();
 
-      #region Private Methods
+            var result = (short)0;
+            var isNeg = value[0] == '-' ? (short)-1 : (short)1;
+            var digits = ExtractCoreDigits(value);
 
-      private static string Format(ICustomFormatter formatter,
-                                   string fmt,
-                                   object value,
-                                   IFormatProvider formatProvider)
-      {
-         if (formatter is IntegerEncoder intFormatter) return intFormatter.FormatObject(value);
+            foreach (var digit in digits)
+            {
+                checked
+                {
+                    result *= (short)Base;
 
-         return formatter.Format(fmt, value, formatProvider);
-      }
+                    if (!_charToValue.ContainsKey(digit))
+                    {
+                        throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
+                    }
 
-      private static string ExtractCoreDigits(string value)
-      {
-         var isNeg = value[0] == '-';
-         var s = isNeg ? 1 : 0;
-         var l = value.Length - s;
-         value = value.Substring(s, l);
+                    result += (short)(_charToValue[digit] * isNeg);
+                }
+            }
 
-         return value;
-      }
+            return result;
+        }
 
-      private string FormatObject(object value)
-      {
-         // ReSharper disable once SwitchStatementMissingSomeEnumCasesNoDefault
-         // ReSharper disable once ConvertSwitchStatementToSwitchExpression
-         switch (Type.GetTypeCode(value.GetType()))
-         {
-            case TypeCode.Byte:
+        /// <inheritdoc />
+        public int ParseInt32(string value)
+        {
+            Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
 
-               return Format((byte) value);
+            if (!CaseSensitive) value = value.ToUpperInvariant();
 
-            case TypeCode.SByte:
+            var result = 0;
+            var isNeg = value[0] == '-' ? -1 : 1;
+            var digits = ExtractCoreDigits(value);
 
-               return Format((sbyte) value);
+            foreach (var digit in digits)
+            {
+                checked
+                {
+                    result *= Base;
 
-            case TypeCode.UInt16:
+                    if (!_charToValue.ContainsKey(digit))
+                    {
+                        throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
+                    }
 
-               return Format((ushort) value);
+                    result += _charToValue[digit] * isNeg;
+                }
+            }
 
-            case TypeCode.UInt32:
+            return result;
+        }
 
-               return Format((uint) value);
+        /// <inheritdoc />
+        public long ParseInt64(string value)
+        {
+            Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
 
-            case TypeCode.UInt64:
+            if (!CaseSensitive) value = value.ToUpperInvariant();
 
-               return Format((ulong) value);
+            var result = (long)0;
+            var isNeg = value[0] == '-'; // ? -1 : 1;
+            var digits = ExtractCoreDigits(value);
 
-            case TypeCode.Int16:
+            foreach (var digit in digits)
+            {
+                checked
+                {
+                    result *= Base;
 
-               return Format((short) value);
+                    if (!_charToValue.ContainsKey(digit))
+                    {
+                        throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
+                    }
 
-            case TypeCode.Int32:
+                    result += _charToValue[digit] * (isNeg ? -1 : 1);
+                }
+            }
 
-               return Format((int) value);
+            return result;
+        }
 
-            case TypeCode.Int64:
+        /// <inheritdoc />
+        public sbyte ParseSByte(string value)
+        {
+            Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
 
-               return Format((long) value);
-         }
+            if (!CaseSensitive) value = value.ToUpperInvariant();
 
-         return value.IsIntegerType() ? Format((BigInteger) value) : value.ToString();
-      }
+            var result = (sbyte)0;
+            var isNeg = (sbyte)(value[0] == '-' ? -1 : 1);
+            var digits = ExtractCoreDigits(value);
 
-      private string FormatResult(List<char> sb)
-      {
-         if (sb.Count == 0) sb.Add(CharacterSet[0]);
+            foreach (var digit in digits)
+            {
+                checked
+                {
+                    result *= (sbyte)Base;
 
-         sb.Reverse();
+                    if (!_charToValue.ContainsKey(digit))
+                    {
+                        throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
+                    }
 
-         return string.Join("", sb);
-      }
+                    result += (sbyte)(_charToValue[digit] * isNeg);
+                }
+            }
 
-      #endregion Private Methods
-   }
+            return result;
+        }
+
+        /// <inheritdoc />
+        public ushort ParseUInt16(string value)
+        {
+            Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
+
+            if (!CaseSensitive) value = value.ToUpperInvariant();
+
+            var result = (ushort)0;
+
+            if (value[0] == '-')
+            {
+                throw new ArgumentException("A negative number cannot be converted into unsigned.", nameof(value));
+            }
+
+            var digits = ExtractCoreDigits(value);
+
+            foreach (var digit in digits)
+            {
+                checked
+                {
+                    result *= Base;
+
+                    if (!_charToValue.ContainsKey(digit))
+                    {
+                        throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
+                    }
+
+                    result += (ushort)_charToValue[digit];
+                }
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public uint ParseUInt32(string value)
+        {
+            Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
+
+            if (!CaseSensitive) value = value.ToUpperInvariant();
+
+            var result = (uint)0;
+
+            if (value[0] == '-')
+            {
+                throw new ArgumentException("A negative number cannot be converted into unsigned.", nameof(value));
+            }
+
+            var digits = ExtractCoreDigits(value);
+
+            foreach (var digit in digits)
+            {
+                checked
+                {
+                    result *= Base;
+
+                    if (!_charToValue.ContainsKey(digit))
+                    {
+                        throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
+                    }
+
+                    result += (uint)_charToValue[digit];
+                }
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public ulong ParseUInt64(string value)
+        {
+            Argument.IsNotNullWhitespaceOrEmpty(value, nameof(value));
+
+            if (!CaseSensitive) value = value.ToUpperInvariant();
+
+            var result = (ulong)0;
+
+            if (value[0] == '-')
+            {
+                throw new ArgumentException("A negative number cannot be converted into unsigned.", nameof(value));
+            }
+
+            var digits = ExtractCoreDigits(value);
+
+            foreach (var digit in digits)
+            {
+                checked
+                {
+                    result *= Base;
+
+                    if (!_charToValue.ContainsKey(digit))
+                    {
+                        throw new ArgumentOutOfRangeException($"{digit} cannont be decoded.");
+                    }
+
+                    result += (ulong)_charToValue[digit];
+                }
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public bool TryParseBigInteger(string value, out BigInteger result)
+        {
+            result = default;
+            try
+            {
+                result = ParseBigInteger(value);
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool TryParseByte(string value, out byte result)
+        {
+            result = default;
+            try
+            {
+                result = ParseByte(value);
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool TryParseInt16(string value, out short result)
+        {
+            result = default;
+            try
+            {
+                result = ParseInt16(value);
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool TryParseInt32(string value, out int result)
+        {
+            result = default;
+            try
+            {
+                result = ParseInt32(value);
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool TryParseInt64(string value, out long result)
+        {
+            result = default;
+            try
+            {
+                result = ParseInt64(value);
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool TryParseSByte(string value, out sbyte result)
+        {
+            result = default;
+            try
+            {
+                result = ParseSByte(value);
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool TryParseUInt16(string value, out ushort result)
+        {
+            result = default;
+            try
+            {
+                result = ParseUInt16(value);
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool TryParseUInt32(string value, out uint result)
+        {
+            result = default;
+            try
+            {
+                result = ParseUInt32(value);
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool TryParseUInt64(string value, out ulong result)
+        {
+            result = default;
+            try
+            {
+                result = ParseUInt64(value);
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        #endregion Public Methods
+
+        #region Private Methods
+
+        private static string Format(ICustomFormatter formatter,
+                                     string fmt,
+                                     object value,
+                                     IFormatProvider formatProvider)
+        {
+            if (formatter is IntegerEncoder intFormatter) return intFormatter.FormatObject(value);
+
+            return formatter.Format(fmt, value, formatProvider);
+        }
+
+        private static string ExtractCoreDigits(string value)
+        {
+            var isNeg = value[0] == '-';
+            var s = isNeg ? 1 : 0;
+            var l = value.Length - s;
+            value = value.Substring(s, l);
+
+            return value;
+        }
+
+        private string FormatObject(object value)
+        {
+            // ReSharper disable once SwitchStatementMissingSomeEnumCasesNoDefault
+            // ReSharper disable once ConvertSwitchStatementToSwitchExpression
+            switch (Type.GetTypeCode(value.GetType()))
+            {
+                case TypeCode.Byte:
+
+                    return Format((byte)value);
+
+                case TypeCode.SByte:
+
+                    return Format((sbyte)value);
+
+                case TypeCode.UInt16:
+
+                    return Format((ushort)value);
+
+                case TypeCode.UInt32:
+
+                    return Format((uint)value);
+
+                case TypeCode.UInt64:
+
+                    return Format((ulong)value);
+
+                case TypeCode.Int16:
+
+                    return Format((short)value);
+
+                case TypeCode.Int32:
+
+                    return Format((int)value);
+
+                case TypeCode.Int64:
+
+                    return Format((long)value);
+            }
+
+            return value.IsIntegerType() ? Format((BigInteger)value) : value.ToString();
+        }
+
+        private string FormatResult(List<char> sb)
+        {
+            if (sb.Count == 0) sb.Add(CharacterSet[0]);
+
+            sb.Reverse();
+
+            return string.Join("", sb);
+        }
+
+        #endregion Private Methods
+    }
 }

--- a/Jcd.Formatting/Jcd.Formatting.csproj
+++ b/Jcd.Formatting/Jcd.Formatting.csproj
@@ -4,18 +4,18 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Title>Jcd.Formatting</Title>
         <Authors>Jason C Daniels</Authors>
-        <Description>A library to simplify implementing IFormatProvider and ICustomFormatter as well as arbitrary integer encoding (e.g. Base 31 is you please)</Description>
-        <Copyright>2018-2021</Copyright>
+        <Description>A library to simplify implementing IFormatProvider and ICustomFormatter as well as arbitrary integer encoding (e.g. Base 36)</Description>
+        <Copyright>2018-2023</Copyright>
         <PackageProjectUrl>https://github.com/jason-c-daniels/Jcd.Formatting</PackageProjectUrl>
         <PackageLicenseUrl>https://github.com/jason-c-daniels/Jcd.Formatting/blob/main/LICENSE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/jason-c-daniels/Jcd.Formatting</RepositoryUrl>
         <RepositoryType>GitHub</RepositoryType>
         <PackageTags>csharp c# formatting integer encoding</PackageTags>
-        <AssemblyVersion>1.0.1</AssemblyVersion>
-        <FileVersion>1.0.1</FileVersion>
-        <PackageVersion>1.0.1</PackageVersion>
+        <AssemblyVersion>2.0.1</AssemblyVersion>
+        <FileVersion>2.0.1</FileVersion>
+        <PackageVersion>2.0.1</PackageVersion>
         <PackageIconUrl>https://s.gravatar.com/avatar/c7e8df18f543ea857ac93660a190df98?s=320</PackageIconUrl>
-        <PackageReleaseNotes>Upgraded Jcd.Validations to 1.0.8 and Jcd.Reflection to 1.0.12</PackageReleaseNotes>
+        <PackageReleaseNotes>Changed from ref to out on IIntegerParser</PackageReleaseNotes>
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
     <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Jcd.Formatting
 A library to simplify implementing IFormatProvider and ICustomFormatter as well as arbitrary integer encoding (e.g. Base 31 if you please)
 
+## Change Log
+
+### 2.0 
+- IIntegerParser.`TryParseXYZ` methods now use an `out` instead of taking a `ref`.
+- IntegerEncoder - Case insensitive alphabets now emit uppercase letters when calling format.
+
 [![GitHub](https://img.shields.io/github/license/jason-c-daniels/Jcd.Formatting)](https://github.com/jason-c-daniels/Jcd.Formatting/blob/main/LICENSE)
 [![Build status](https://ci.appveyor.com/api/projects/status/5lhmo0cnj8wc80yn?svg=true)](https://ci.appveyor.com/project/jason-c-daniels/jcd-formatting)
 [![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/jason-c-daniels/Jcd.Formatting)](https://www.codefactor.io/repository/github/jason-c-daniels/jcd.formatting)

--- a/docs/Jcd_Formatting_IIntegerParser_TryParseBigInteger(string_System_Numerics_BigInteger).md
+++ b/docs/Jcd_Formatting_IIntegerParser_TryParseBigInteger(string_System_Numerics_BigInteger).md
@@ -2,7 +2,7 @@
 ## IIntegerParser.TryParseBigInteger(string, BigInteger) Method
 Tries to parse a BigInteger from the provided text.  
 ```csharp
-bool TryParseBigInteger(string value, ref System.Numerics.BigInteger result);
+bool TryParseBigInteger(string value, out System.Numerics.BigInteger result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IIntegerParser_TryParseBigInteger(string_System_Numerics_BigInteger)_value'></a>

--- a/docs/Jcd_Formatting_IIntegerParser_TryParseByte(string_byte).md
+++ b/docs/Jcd_Formatting_IIntegerParser_TryParseByte(string_byte).md
@@ -2,7 +2,7 @@
 ## IIntegerParser.TryParseByte(string, byte) Method
 Tries to parse a Byte from the provided text.  
 ```csharp
-bool TryParseByte(string value, ref byte result);
+bool TryParseByte(string value, out byte result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IIntegerParser_TryParseByte(string_byte)_value'></a>

--- a/docs/Jcd_Formatting_IIntegerParser_TryParseInt16(string_short).md
+++ b/docs/Jcd_Formatting_IIntegerParser_TryParseInt16(string_short).md
@@ -2,7 +2,7 @@
 ## IIntegerParser.TryParseInt16(string, short) Method
 Tries to parse a Int16 from the provided text.  
 ```csharp
-bool TryParseInt16(string value, ref short result);
+bool TryParseInt16(string value, out short result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IIntegerParser_TryParseInt16(string_short)_value'></a>

--- a/docs/Jcd_Formatting_IIntegerParser_TryParseInt32(string_int).md
+++ b/docs/Jcd_Formatting_IIntegerParser_TryParseInt32(string_int).md
@@ -2,7 +2,7 @@
 ## IIntegerParser.TryParseInt32(string, int) Method
 Tries to parse a Int32 from the provided text.  
 ```csharp
-bool TryParseInt32(string value, ref int result);
+bool TryParseInt32(string value, out int result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IIntegerParser_TryParseInt32(string_int)_value'></a>

--- a/docs/Jcd_Formatting_IIntegerParser_TryParseInt64(string_long).md
+++ b/docs/Jcd_Formatting_IIntegerParser_TryParseInt64(string_long).md
@@ -2,7 +2,7 @@
 ## IIntegerParser.TryParseInt64(string, long) Method
 Tries to parse a Int64 from the provided text.  
 ```csharp
-bool TryParseInt64(string value, ref long result);
+bool TryParseInt64(string value, out long result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IIntegerParser_TryParseInt64(string_long)_value'></a>

--- a/docs/Jcd_Formatting_IIntegerParser_TryParseSByte(string_sbyte).md
+++ b/docs/Jcd_Formatting_IIntegerParser_TryParseSByte(string_sbyte).md
@@ -2,7 +2,7 @@
 ## IIntegerParser.TryParseSByte(string, sbyte) Method
 Tries to parse a SByte from the provided text.  
 ```csharp
-bool TryParseSByte(string value, ref sbyte result);
+bool TryParseSByte(string value, out sbyte result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IIntegerParser_TryParseSByte(string_sbyte)_value'></a>

--- a/docs/Jcd_Formatting_IIntegerParser_TryParseUInt16(string_ushort).md
+++ b/docs/Jcd_Formatting_IIntegerParser_TryParseUInt16(string_ushort).md
@@ -2,7 +2,7 @@
 ## IIntegerParser.TryParseUInt16(string, ushort) Method
 Tries to parse a UInt16 from the provided text.  
 ```csharp
-bool TryParseUInt16(string value, ref ushort result);
+bool TryParseUInt16(string value, out ushort result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IIntegerParser_TryParseUInt16(string_ushort)_value'></a>

--- a/docs/Jcd_Formatting_IIntegerParser_TryParseUInt32(string_uint).md
+++ b/docs/Jcd_Formatting_IIntegerParser_TryParseUInt32(string_uint).md
@@ -2,7 +2,7 @@
 ## IIntegerParser.TryParseUInt32(string, uint) Method
 Tries to parse a UInt32 from the provided text.  
 ```csharp
-bool TryParseUInt32(string value, ref uint result);
+bool TryParseUInt32(string value, out uint result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IIntegerParser_TryParseUInt32(string_uint)_value'></a>

--- a/docs/Jcd_Formatting_IIntegerParser_TryParseUInt64(string_ulong).md
+++ b/docs/Jcd_Formatting_IIntegerParser_TryParseUInt64(string_ulong).md
@@ -2,7 +2,7 @@
 ## IIntegerParser.TryParseUInt64(string, ulong) Method
 Tries to parse a UInt64 from the provided text.  
 ```csharp
-bool TryParseUInt64(string value, ref ulong result);
+bool TryParseUInt64(string value, out ulong result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IIntegerParser_TryParseUInt64(string_ulong)_value'></a>

--- a/docs/Jcd_Formatting_IntegerEncoder_TryParseBigInteger(string_System_Numerics_BigInteger).md
+++ b/docs/Jcd_Formatting_IntegerEncoder_TryParseBigInteger(string_System_Numerics_BigInteger).md
@@ -2,7 +2,7 @@
 ## IntegerEncoder.TryParseBigInteger(string, BigInteger) Method
 Tries to parse a BigInteger from the provided text.  
 ```csharp
-public bool TryParseBigInteger(string value, ref System.Numerics.BigInteger result);
+public bool TryParseBigInteger(string value, out System.Numerics.BigInteger result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IntegerEncoder_TryParseBigInteger(string_System_Numerics_BigInteger)_value'></a>

--- a/docs/Jcd_Formatting_IntegerEncoder_TryParseByte(string_byte).md
+++ b/docs/Jcd_Formatting_IntegerEncoder_TryParseByte(string_byte).md
@@ -2,7 +2,7 @@
 ## IntegerEncoder.TryParseByte(string, byte) Method
 Tries to parse a Byte from the provided text.  
 ```csharp
-public bool TryParseByte(string value, ref byte result);
+public bool TryParseByte(string value, out byte result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IntegerEncoder_TryParseByte(string_byte)_value'></a>

--- a/docs/Jcd_Formatting_IntegerEncoder_TryParseInt16(string_short).md
+++ b/docs/Jcd_Formatting_IntegerEncoder_TryParseInt16(string_short).md
@@ -2,7 +2,7 @@
 ## IntegerEncoder.TryParseInt16(string, short) Method
 Tries to parse a Int16 from the provided text.  
 ```csharp
-public bool TryParseInt16(string value, ref short result);
+public bool TryParseInt16(string value, out short result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IntegerEncoder_TryParseInt16(string_short)_value'></a>

--- a/docs/Jcd_Formatting_IntegerEncoder_TryParseInt32(string_int).md
+++ b/docs/Jcd_Formatting_IntegerEncoder_TryParseInt32(string_int).md
@@ -2,7 +2,7 @@
 ## IntegerEncoder.TryParseInt32(string, int) Method
 Tries to parse a Int32 from the provided text.  
 ```csharp
-public bool TryParseInt32(string value, ref int result);
+public bool TryParseInt32(string value, out int result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IntegerEncoder_TryParseInt32(string_int)_value'></a>

--- a/docs/Jcd_Formatting_IntegerEncoder_TryParseInt64(string_long).md
+++ b/docs/Jcd_Formatting_IntegerEncoder_TryParseInt64(string_long).md
@@ -2,7 +2,7 @@
 ## IntegerEncoder.TryParseInt64(string, long) Method
 Tries to parse a Int64 from the provided text.  
 ```csharp
-public bool TryParseInt64(string value, ref long result);
+public bool TryParseInt64(string value, out long result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IntegerEncoder_TryParseInt64(string_long)_value'></a>

--- a/docs/Jcd_Formatting_IntegerEncoder_TryParseSByte(string_sbyte).md
+++ b/docs/Jcd_Formatting_IntegerEncoder_TryParseSByte(string_sbyte).md
@@ -2,7 +2,7 @@
 ## IntegerEncoder.TryParseSByte(string, sbyte) Method
 Tries to parse a SByte from the provided text.  
 ```csharp
-public bool TryParseSByte(string value, ref sbyte result);
+public bool TryParseSByte(string value, out sbyte result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IntegerEncoder_TryParseSByte(string_sbyte)_value'></a>

--- a/docs/Jcd_Formatting_IntegerEncoder_TryParseUInt16(string_ushort).md
+++ b/docs/Jcd_Formatting_IntegerEncoder_TryParseUInt16(string_ushort).md
@@ -2,7 +2,7 @@
 ## IntegerEncoder.TryParseUInt16(string, ushort) Method
 Tries to parse a UInt16 from the provided text.  
 ```csharp
-public bool TryParseUInt16(string value, ref ushort result);
+public bool TryParseUInt16(string value, out ushort result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IntegerEncoder_TryParseUInt16(string_ushort)_value'></a>

--- a/docs/Jcd_Formatting_IntegerEncoder_TryParseUInt32(string_uint).md
+++ b/docs/Jcd_Formatting_IntegerEncoder_TryParseUInt32(string_uint).md
@@ -2,7 +2,7 @@
 ## IntegerEncoder.TryParseUInt32(string, uint) Method
 Tries to parse a UInt32 from the provided text.  
 ```csharp
-public bool TryParseUInt32(string value, ref uint result);
+public bool TryParseUInt32(string value, out uint result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IntegerEncoder_TryParseUInt32(string_uint)_value'></a>

--- a/docs/Jcd_Formatting_IntegerEncoder_TryParseUInt64(string_ulong).md
+++ b/docs/Jcd_Formatting_IntegerEncoder_TryParseUInt64(string_ulong).md
@@ -2,7 +2,7 @@
 ## IntegerEncoder.TryParseUInt64(string, ulong) Method
 Tries to parse a UInt64 from the provided text.  
 ```csharp
-public bool TryParseUInt64(string value, ref ulong result);
+public bool TryParseUInt64(string value, out ulong result);
 ```
 #### Parameters
 <a name='Jcd_Formatting_IntegerEncoder_TryParseUInt64(string_ulong)_value'></a>


### PR DESCRIPTION
- IIntegerParser.`TryParseXYZ` methods now use an `out` instead of ta…king a `ref`.

- IntegerEncoder - Case insensitive alphabets now emit uppercase letters when calling format.